### PR TITLE
Replace haste imports with path-based imports

### DIFF
--- a/js/AndroidCheckBoxNativeComponent.js
+++ b/js/AndroidCheckBoxNativeComponent.js
@@ -9,11 +9,11 @@
  */
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const {requireNativeComponent} = require('react-native');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {NativeComponent} from 'react-native/Libraries/Renderer/shims/ReactNative';
 
 type CheckBoxEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/js/CheckBox.android.js
+++ b/js/CheckBox.android.js
@@ -9,18 +9,18 @@
  */
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const processColor = require('processColor');
+const nullthrows = require('nullthrows');
+const React = require('react');
+const {StyleSheet} = require('react-native');
+const processColor = require('react-native/Libraries/StyleSheet/processColor');
+const setAndForwardRef = require('react-native/Libraries/Utilities/setAndForwardRef');
 
 const AndroidCheckBoxNativeComponent = require('./AndroidCheckBoxNativeComponent');
-const nullthrows = require('nullthrows');
-const setAndForwardRef = require('setAndForwardRef');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {NativeComponent} from 'ReactNative';
-import type {ColorValue} from 'StyleSheetTypes';
+import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type {NativeComponent} from 'react-native/Libraries/Renderer/shims/ReactNative';
+import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
+import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 
 type CheckBoxEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/js/CheckBox.ios.js
+++ b/js/CheckBox.ios.js
@@ -9,4 +9,4 @@
  */
 'use strict';
 
-module.exports = require('UnimplementedView');
+module.exports = require('react-native/Libraries/Components/UnimplementedViews/UnimplementedView');


### PR DESCRIPTION
# Summary
Haste imports have been removed from react-native in 0.60.0. This PR replaces those imports with path-based ones so that the CheckBox component will work with react-native 0.60.0+.

Fixes https://github.com/react-native-community/react-native-checkbox/issues/3
Fixes https://github.com/facebook/react-native/issues/25558

## Test Plan
A react-native 0.60.0 app that imports @react-native-community/checkbox will compile and not crash the metro bundler. 

### What's required for testing (prerequisites)?
A react-native 0.60.0 app, this module

### What are the steps to reproduce (after prerequisites)?
Build the app 

## Compatibility

| OS      | Implemented | |
| ------- | :---------: | --- |
| iOS     |    ✅     | CheckBox is not supported on iOS but I've updated the `UnimplementedView` import |
| Android |    ✅     | |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
