### PR TITLE
Replace Support lib with AndroidX

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/checkbox/ReactCheckBox.java
+++ b/android/src/main/java/com/reactnativecommunity/checkbox/ReactCheckBox.java
@@ -7,7 +7,7 @@
 package com.reactnativecommunity.checkbox;
 
 import android.content.Context;
-import android.support.v7.widget.AppCompatCheckBox;
+import androidx.appcompat.widget.AppCompatCheckBox;
 
 /** CheckBox that has its value controlled by JS. */
 /*package*/ class ReactCheckBox extends AppCompatCheckBox {

--- a/android/src/main/java/com/reactnativecommunity/checkbox/ReactCheckBoxManager.java
+++ b/android/src/main/java/com/reactnativecommunity/checkbox/ReactCheckBoxManager.java
@@ -8,8 +8,8 @@ package com.reactnativecommunity.checkbox;
 
 import android.content.Context;
 import android.content.res.ColorStateList;
-import android.support.v4.widget.CompoundButtonCompat;
-import android.support.v7.widget.TintContextWrapper;
+import androidx.core.widget.CompoundButtonCompat;
+import androidx.appcompat.widget.TintContextWrapper;
 import android.util.TypedValue;
 import android.widget.CompoundButton;
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,3 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
-  plugins: ['@babel/plugin-proposal-class-properties'],
 }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "yarn test:eslint && yarn test:flow && yarn test:jest",
-    "test:eslint": "eslint 'js/**/*.js' 'example/**/*.js'",
-    "test:flow": "flow check",
-    "test:js": "jest",
+    "test:eslint": "yarn eslint 'js/**/*.js' 'example/**/*.js'",
+    "test:flow": "yarn flow check",
+    "test:js": "yarn jest",
     "ci:test:flow": "yarn test:flow",
     "ci:test:js": "yarn test:js"
   },

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "react-native": "*"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-class-properties": "^7.4.0",
-    "babel-core": "^7.0.0-bridge.0",
+    "@babel/core": "^7.5.5",
+    "@babel/runtime": "^7.5.5",
     "babel-eslint": "^10.0.1",
-    "babel-plugin-module-resolver": "^3.1.3",
-    "eslint": "5.13.0",
+    "babel-jest": "^24.8.0",
+    "eslint": "^6.10.0",
     "eslint-plugin-eslint-comments": "^3.0.1",
     "eslint-plugin-flowtype": "3.2.1",
     "eslint-plugin-jest": "22.2.2",
@@ -41,12 +41,12 @@
     "eslint-plugin-react-hooks": "^1.0.1",
     "eslint-plugin-react-native": "3.6.0",
     "flow-bin": "^0.86.0",
-    "jest": "^24.7.1",
-    "metro-react-native-babel-preset": "0.51.1",
+    "jest": "^24.8.0",
+    "metro-react-native-babel-preset": "^0.55.0",
     "prettier": "^1.16.4",
-    "react": "16.6.3",
-    "react-native": "0.58.4",
-    "react-test-renderer": "^16.8.6"
+    "react": "16.8.6",
+    "react-native": "0.60.4",
+    "react-test-renderer": "16.8.6"
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
# Summary
Breaking change, upgrades the package to use AndroidX instead of the Support library.

Not sure if this is that important at the moment, as it's easy enough to use jetifier to make the same change, but seeing as this has been newly extracted and deprecated for RN 0.60.0 it seems likely that most users of this package would be on RN 0.60.0 or above, so don't need android support library compatibility.

## Test Plan
Install package in a new RN 0.60.0 app (without jetify set up)

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
