### PR TITLE
Fix 'pod install' error when using react-native >= 0.60

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ or
 
 ### Mostly automatic installation
 
+From react-native >= 0.60 autolinking will take care of the link, just don't forget to run pod install after adding this pakage
+
+for react-native =< 0.59.X
+
 `react-native link @react-native-community/checkbox`
 
 ### Manual installation

--- a/ios/RNCReactNativeCheckbox.podspec
+++ b/ios/RNCReactNativeCheckbox.podspec
@@ -1,24 +1,24 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = "RNCReactNativeCheckbox"
-  s.version      = "1.0.0"
-  s.summary      = "RNCReactNativeCheckbox"
-  s.description  = <<-DESC
-                  RNCReactNativeCheckbox
-                   DESC
-  s.homepage     = ""
-  s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
-  s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNCReactNativeCheckbox.git", :tag => "master" }
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+
+  s.description  = package['description']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/react-native-community/react-native-checkbox.git", :tag => "master" }
   s.source_files  = "RNCReactNativeCheckbox/**/*.{h,m}"
   s.requires_arc = true
 
-
   s.dependency "React"
-  #s.dependency "others"
 
 end
 
-  

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@react-native-community/checkbox",
+  "name": "react-native-checkbox",
   "version": "0.1.0",
   "license": "MIT",
   "description": "React Native Checkbox native modules for iOS & Android",
@@ -61,5 +61,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/react-native-checkbox.git"
-  }
+  },
+  "homepage": "https://github.com/react-native-community/react-native-checkbox#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-checkbox",
+  "name": "@react-native-community/checkbox",
   "version": "0.1.0",
   "license": "MIT",
   "description": "React Native Checkbox native modules for iOS & Android",

--- a/react-native-checkbox.podspec
+++ b/react-native-checkbox.podspec
@@ -1,6 +1,6 @@
 require 'json'
 
-package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
+package = JSON.parse(File.read(File.join(__dir__, '/package.json')))
 
 Pod::Spec.new do |s|
   s.name         = package['name']
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "9.0"
 
   s.source       = { :git => "https://github.com/react-native-community/react-native-checkbox.git", :tag => "master" }
-  s.source_files  = "RNCReactNativeCheckbox/**/*.{h,m}"
+  s.source_files  = "ios/RNCReactNativeCheckbox/**/*.{h,m}"
   s.requires_arc = true
 
   s.dependency "React"


### PR DESCRIPTION
# Summary
This change will make this package workin on RN 0.60.0 or above,
Not sure if this is important at the moment, but i have an error when i am tring to install for RN 0.60.4
```
Detected React Native module pods for RNCReactNativeCheckbox, react-native-cameraroll, react-native-image-editor, react-native-netinfo, and react-native-webview
Analyzing dependencies
Fetching podspec for `RNCReactNativeCheckbox` from `../node_modules/@react-native-community/checkbox/ios`
[!] The `RNCReactNativeCheckbox` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.

```

## Test Plan
1. Create a fresh react-native project
2. Add this package with command `yarn` or `npm``
3. run inside your project :```cd ios && pod install```

### What's required for testing (prerequisites)?
1. A fresh react-native project

### What are the steps to reproduce (after prerequisites)?
Use the library in the project

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist


- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
