### PR TITLE
docs: update documentation links to reactnative.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Check out the [example project](example) for more examples.
 ### Props
 
 
-[View props...](https://facebook.github.io/react-native/docs/view#props)
+[View props...](https://reactnative.dev/docs/view#props)
 
 | Prop name     | Description                                                                                                                                                                                                           |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -18,7 +18,7 @@ import com.android.build.OutputFile
  *   // the entry file for bundle generation
  *   entryFile: "index.android.js",
  *
- *   // https://facebook.github.io/react-native/docs/performance#enable-the-ram-format
+ *   // https://reactnative.dev/docs/performance#enable-the-ram-format
  *   bundleCommand: "ram-bundle",
  *
  *   // whether to bundle JS and assets in debug mode
@@ -156,7 +156,7 @@ android {
         }
         release {
             // Caution! In production, you need to generate your own keystore file.
-            // see https://facebook.github.io/react-native/docs/signed-apk-android.
+            // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"


### PR DESCRIPTION
# Summary
This PR update react native docs links to new domain: reactnative.dev

## Test Plan
Open links in changed files