### PR TITLE
fix: trigger onChange prop callback on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Check out the [example project](example) for more examples.
 | Prop name     | Type    | Description                                                                                                                                                                                                           |
 | ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | lineWidth     | boolean | The width of the lines of the check mark and box. Defaults to 2.0.                                                                                                                                        |
-| hideBox       | boolean | ontrol if the box should be hidden or not. Defaults to false |
+| hideBox       | boolean | Control if the box should be hidden or not. Defaults to false |
 | boxType       | 'circle' or 'square' |  The type of box to use. Defaults to 'circle' |
 | tintColor     | string  | The color of the box when the checkbox is Off. Defaults to '#aaaaaa' |
 | onCheckColor  | string  | The color of the check mark when it is On. Defaults to '#007aff' |

--- a/src/js/CheckBox.ios.tsx
+++ b/src/js/CheckBox.ios.tsx
@@ -103,11 +103,12 @@ class CheckBox extends React.Component<Props> {
   });
 
   _onChange = (event: CheckBoxEvent) => {
-    const {onValueChange} = this.props;
+    const {onValueChange, onChange} = this.props;
 
     const {value} = event.nativeEvent;
     // @ts-ignore
     nullthrows(this._nativeRef).setNativeProps({value});
+    onChange && onChange(event);
     onValueChange && onValueChange(value);
   };
 


### PR DESCRIPTION
# Summary

Add a call to `props.onChange`, just like it's added for android

* What areas of the library does it impact?
- iOS

## Test Plan

It's a 2 line, functional change, only calling a property that already exists, bringing to parity with android.

### What's required for testing (prerequisites)?
Nothing

### What are the steps to reproduce (after prerequisites)?
Supply `onChange` to `CheckBox` on iOS and observe it being called when the state of the checkbox changes

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
