### PR TITLE
Make tintColors fields optional

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -125,6 +125,7 @@ export default class App extends Component<Props, State> {
         <Text>{`[value: ${this.state.value1}]`}</Text>
         <CheckBox
           value={this.state.value1}
+          tintColors={{true: '#ff0000'}}
           onValueChange={(value) =>
             this.setState({
               value1: value,

--- a/src/js/CheckBox.android.tsx
+++ b/src/js/CheckBox.android.tsx
@@ -57,7 +57,7 @@ type NativeProps = Readonly<
   CommonProps & {
     on?: boolean;
     enabled?: boolean;
-    tintColors: {true: any; false: any} | undefined;
+    tintColors: {true?: any; false?: any} | undefined;
   }
 >;
 
@@ -80,7 +80,7 @@ export type Props = Readonly<
      * Controls the colors the checkbox has in checked and unchecked states.
      * TODO: improve this type
      */
-    tintColors?: {true: any; false: any};
+    tintColors?: {true?: any; false?: any};
   }
 >;
 
@@ -161,7 +161,7 @@ class CheckBox extends React.Component<Props> {
       this.props.onValueChange(event.nativeEvent.value);
   };
 
-  getTintColors(tintColors: {true: any; false: any} | undefined) {
+  getTintColors(tintColors: {true?: any; false?: any} | undefined) {
     return tintColors
       ? {
           true: processColor(tintColors.true),


### PR DESCRIPTION
# Summary
The tintColors fields should be optional

## Test Plan
<img src="https://user-images.githubusercontent.com/46004092/93291081-6dd6d500-f7f7-11ea-811c-1475638eaaf2.png" width="200" height="400" />

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md` ( the document already is ok )
- [ ] I mentioned this change in `CHANGELOG.md` ( where is the CHANGELOG.md :| )
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)